### PR TITLE
Corrección de cálculo de campo para Análisis de facturas.

### DIFF
--- a/pchouse_account/__manifest__.py
+++ b/pchouse_account/__manifest__.py
@@ -16,7 +16,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Account',
-    'version': '14.0',
+    'version': '14.0.1.0',
 
     # any module necessary for this one to work correctly
     'depends': ['base', 'account'],

--- a/pchouse_account/__manifest__.py
+++ b/pchouse_account/__manifest__.py
@@ -25,6 +25,7 @@
     'data': [
         # 'security/ir.model.access.csv',
         'views/account_move_views.xml'
+        'views/account_invoice_report_views.xml'
         
     ],
 }

--- a/pchouse_account/__manifest__.py
+++ b/pchouse_account/__manifest__.py
@@ -16,7 +16,7 @@
     # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Account',
-    'version': '14.0.1.0',
+    'version': '14.0.1.1',
 
     # any module necessary for this one to work correctly
     'depends': ['base', 'account'],

--- a/pchouse_account/models/account_invoice_report.py
+++ b/pchouse_account/models/account_invoice_report.py
@@ -1,0 +1,18 @@
+from odoo import models, fields, api
+
+
+class AccountInvoiceReport(models.Model):
+    _inherit = "account.invoice.report"
+
+    line_total_cost = fields.Char(string="Costo Total")
+    price_with_tax = fields.Char(string="Precio con IVA")
+
+    def _select(self):
+        select_str = super(AccountInvoiceReport, self)._select()
+        select_str += ", line.line_total_cost, line.price_with_tax"
+        return select_str
+
+    def _group_by(self):
+        group_by_str = super(AccountInvoiceReport, self)._group_by()
+        group_by_str += ", line.line_total_cost, line.price_with_tax"
+        return group_by_str

--- a/pchouse_account/models/account_move.py
+++ b/pchouse_account/models/account_move.py
@@ -11,13 +11,13 @@ class AccountMove(models.Model):
         currency_field="currency_id"
     )
 
-    @api.depends('invoice_line_ids', 'invoice_line_ids.product_id', 'invoice_line_ids.quantity')
+    @api.depends('invoice_line_ids', 'invoice_line_ids.historical_cost', 'invoice_line_ids.product_id', 'invoice_line_ids.quantity')
     def _compute_total_cost(self):
         for move in self:
             total_cost = 0.0
             for line in move.invoice_line_ids:
                 if line.product_id:
-                    total_cost += line.historical_cost * line.quantity
+                    total_cost += line.line_total_cost
             
             move.total_cost = total_cost
 
@@ -39,3 +39,21 @@ class AccountMoveLine(models.Model):
         string="Costo Histórico",
         currency_field="currency_id"
     )
+    price_with_tax = fields.Float(string="Precio con IVA", compute="_compute_price_with_tax", store=True)
+    line_total_cost = fields.Monetary(
+        string="Costo total",
+        compute="_compute_line_total_cost",
+        store=True,
+        currency_field="currency_id"
+    )
+
+    @api.depends('historical_cost', 'quantity')
+    def _compute_line_total_cost(self):
+        for line in self:
+            line.line_total_cost = line.historical_cost * line.quantity
+
+    @api.depends('price_subtotal', 'tax_ids')
+    def _compute_price_with_tax(self):
+        for line in self:
+            taxes = line.tax_ids.compute_all(line.price_unit, line.move_id.currency_id, line.quantity, product=line.product_id)
+            line.price_with_tax = taxes['total_included']

--- a/pchouse_account/views/account_invoice_report_views.xml
+++ b/pchouse_account/views/account_invoice_report_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_invoice_report_pivot_inherit" model="ir.ui.view">
+        <field name="name">account.invoice.report.pivot.inherit</field>
+        <field name="model">account.invoice.report</field>
+        <field name="inherit_id" ref="account.view_account_invoice_report_pivot"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='price_subtotal']" position="after">
+                <field name="line_total_cost"/>
+                <field name="price_with_tax"/>
+            </xpath>
+        </field>
+    </record>
+
+
+</odoo>
+


### PR DESCRIPTION
Cambios realizados:

En el modelo **account.move.line**:

Se añadió el campo _line_total_cost_, que calcula el costo total de la línea multiplicando el _historical_cost_ por la _quantity_.
Se definió el método _compute_line_total_cost, que recalcula el campo _line_total_cost_ de manera automática al cambiar el costo histórico o la cantidad.

En el modelo **account.move**:

Se actualizó el cálculo del campo _total_cost_ para que sume los valores de _line_total_cost_ de cada línea de factura (invoice_line_ids), garantizando que el total de costo en la lista de facturas se mantenga actualizado en función de las líneas de la factura.