### PR TITLE
Creación de módulo pchouse_stock con gestión personalizada de permisos en inventario.

### DIFF
--- a/pchouse_stock/README.md
+++ b/pchouse_stock/README.md
@@ -1,0 +1,21 @@
+# pchouse_stock
+
+**Gestión Personalizada de Inventario**
+
+Este módulo proporciona una gestión personalizada del inventario para satisfacer las necesidades específicas de la empresa.
+
+---
+
+## Características
+
+1. **Nuevo grupo de usuarios:**
+   - Se crea un grupo llamado **Gestión de Inventario** para manejar operaciones relacionadas con el inventario.
+
+2. **Modificación de permisos del botón "Devolver":**
+   - Los usuarios del grupo **Gestión de Inventario** ahora pueden acceder al botón "Devolver" en las transferencias de stock (`stock.picking`).
+   - Los permisos del grupo **Administradores de Inventario** se mantienen intactos.
+   - Los permisos actuales de otros grupos no se ven afectados.
+
+3. **Seguridad y control:**
+   - Se asegura que las modificaciones no interfieran con otras funcionalidades del modelo `stock.picking`.
+

--- a/pchouse_stock/__init__.py
+++ b/pchouse_stock/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+#from . import controllers
+#from . import models

--- a/pchouse_stock/__manifest__.py
+++ b/pchouse_stock/__manifest__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "pchouse_stock",
+
+    'summary': """
+        Gestión personalizada del inventario para pchouse""",
+
+    'description': """
+        Módulo personalizado para la gestión avanzada de inventario:
+- Creación de un nuevo grupo de usuarios: "Gestión de Inventario".
+- Modificación de permisos para acciones específicas como el botón "Devolver" en transferencias de stock.
+
+Este módulo está diseñado para satisfacer las necesidades específicas de la empresa, mejorando el control y la trazabilidad del inventario.
+    """,
+
+    'author': "joonza",
+    'website': "http://www.joonza.com",
+
+    # Categories can be used to filter modules in modules listing
+    # Check https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/data/ir_module_category_data.xml
+    # for the full list
+    'category': 'Stock',
+    'version': '14.0.1.3',
+
+    # any module necessary for this one to work correctly
+    'depends': ['base', 'stock'],
+
+    # always loaded
+    'data': [
+        # 'security/ir.model.access.csv',
+        'security/pchouse_stock_groups.xml',
+        'views/views.xml',
+    ],
+}

--- a/pchouse_stock/security/ir.model.access.csv
+++ b/pchouse_stock/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_pchouse_stock_pchouse_stock,pchouse_stock.pchouse_stock,model_pchouse_stock_pchouse_stock,base.group_user,1,1,1,1

--- a/pchouse_stock/security/pchouse_stock_groups.xml
+++ b/pchouse_stock/security/pchouse_stock_groups.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Grupo de Gestión de Inventario -->
+        <record id="group_inventory_management" model="res.groups">
+            <field name="name">Gestión de Inventario</field>
+            <field name="category_id" ref="base.module_category_inventory"/>
+            <field name="comment">Usuarios responsables de gestionar el inventario.</field>
+        </record>
+    </data>
+</odoo>

--- a/pchouse_stock/views/views.xml
+++ b/pchouse_stock/views/views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="view_picking_form_inherit" model="ir.ui.view">
+            <field name="name">stock.picking.form.inherit</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='289']" position="attributes">
+                    <attribute name="groups">stock.group_stock_manager, pchouse_stock.group_inventory_management</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Este pull request introduce las siguientes funcionalidades al sistema:

1. Creación de un nuevo módulo `pchouse_stock`:

-   Se añade un módulo personalizado para la gestión avanzada del inventario.

2. Nuevo grupo de usuarios:

-   Se crea el grupo Gestión de Inventario, con permisos específicos para manejar operaciones relacionadas con el inventario.

3. Modificación de permisos en el botón "Devolver" (stock.picking):

-   Los usuarios del grupo Gestión de Inventario pueden acceder al botón "Devolver".

-   Los permisos del grupo Administradores de Inventario permanecen intactos.

-   Se asegura que los permisos de otros grupos o usuarios no se vean afectados.

4. Pruebas realizadas:

-   Validación del acceso al botón "Devolver" por parte de los grupos Gestión de Inventario y Administradores de Inventario.

-   Confirmación de que los usuarios fuera de estos grupos no tienen acceso al botón.

-   Verificación de que no se afecta ninguna otra funcionalidad del modelo `stock.picking`.

5. Documentación actualizada:

-   Se añade un archivo README.md con la descripción del módulo y las características implementadas.