### PR TITLE
Validación de precios base en líneas de Presupuesto con grupo excepcional

### DIFF
--- a/pchouse_sale/__manifest__.py
+++ b/pchouse_sale/__manifest__.py
@@ -23,6 +23,7 @@
 
     # always loaded
     'data': [
+        'data/security_groups.xml',
         'security/ir.model.access.csv',
         'views/sale_order_line_views.xml',
         'views/product_pricelist_views.xml'

--- a/pchouse_sale/data/security_groups.xml
+++ b/pchouse_sale/data/security_groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="group_allow_below_base_price" model="res.groups">
+            <field name="name">Precios por debajo del precio base</field>
+            <field name="category_id" ref="base.module_category_usability"/>
+        </record>
+    </data>
+</odoo>

--- a/pchouse_sale/models/sale_order_line.py
+++ b/pchouse_sale/models/sale_order_line.py
@@ -6,29 +6,29 @@ from odoo.exceptions import ValidationError
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-
-    @api.onchange('product_id')
-    def _onchange_product_id(self):
+    def write(self, vals):
+        res = super(SaleOrderLine, self).write(vals)
+        self._validate_price_unit()
+        return res
+    
+    @api.model
+    def create(self, vals):
+        record = super(SaleOrderLine, self).create(vals)
+        record._validate_price_unit()
+        return record
+    
+    def _validate_price_unit(self):
         for line in self:
+            if self.env.user.has_group('pchouse_sale.group_allow_below_base_price'):
+            # Si el usuario pertenece al grupo, omitir la validación
+                continue
             if line.product_id:
-                tarifa_base_price = self._get_pricelist_base_price(line.product_id)
-                
-                if line.price_unit and line.price_unit < tarifa_base_price:
+                tarifa_base_price = line._get_pricelist_base_price(line.product_id)
+                if line.price_unit < tarifa_base_price:
                     raise ValidationError(
-                        f"El precio ingresado no puede ser menor que el precio base."
+                        f"El precio en la línea para el producto '{line.product_id.name}' "
+                        f"({line.price_unit}) no puede ser menor que el precio base ({tarifa_base_price})."
                     )
-
-    @api.onchange('price_unit')
-    def _onchange_price_unit(self):
-        for line in self:
-            if not self.env.user.has_group('sales_team.group_sale_manager'):
-                if line.product_id:
-                    tarifa_base_price = self._get_pricelist_base_price(line.product_id)
-                    
-                    if line.price_unit < tarifa_base_price:
-                        raise ValidationError(
-                            f"El precio ingresado no puede ser menor que el precio base."
-                        )
 
     def _get_pricelist_base_price(self, product):
         user_groups = self.env.user.groups_id


### PR DESCRIPTION
Este PR implementa las siguientes mejoras y funcionalidades en el módulo pchouse_sale:

**Validación de precios base al guardar o actualizar líneas de presupuesto:**

- El modelo `sale.order.line` ahora valida que el precio ingresado en una línea no sea menor que el precio base configurado en la tarifa correspondiente.

- La validación se realiza exclusivamente al guardar o actualizar la línea del presupuesto.

**Creación de un nuevo grupo de permisos:**

- Se agregó un grupo llamado "Permitir precios por debajo del precio base", ubicado en la categoría "Permisos extra".

- Los usuarios asignados a este grupo pueden establecer precios menores al precio base sin que se active la validación.

**Ajustes en el método de validación:**

El método encargado de verificar los precios ahora omite la validación si el usuario pertenece al grupo "Permitir precios por debajo del precio base".

### Impacto

- Mejora el control sobre los precios establecidos en los presupuestos, garantizando que se respeten las tarifas base a menos que el usuario tenga permisos especiales.

- Permite flexibilidad para usuarios específicos, como Oliver, que requieren establecer precios fuera de los límites estándar.