### PR TITLE
Mejora en la validación de precios en presupuestos de venta

### DIFF
--- a/pchouse_sale/models/sale_order_line.py
+++ b/pchouse_sale/models/sale_order_line.py
@@ -23,6 +23,11 @@ class SaleOrderLine(models.Model):
             # Si el usuario pertenece al grupo, omitir la validación
                 continue
             if line.product_id:
+                partner_pricelist = line.order_id.partner_id.property_product_pricelist
+                if partner_pricelist and partner_pricelist.id != 28:
+                    # Si el cliente tiene una tarifa especial asignada, se usa sin restricciones
+                    return
+                # Si el cliente no tiene una tarifa especial, aplicar la tarifa por grupo del vendedor
                 tarifa_base_price = line._get_pricelist_base_price(line.product_id)
                 if line.price_unit < tarifa_base_price:
                     raise ValidationError(


### PR DESCRIPTION
Este PR ajusta la lógica de validación de precios en las líneas de venta para priorizar la tarifa asignada al cliente y garantizar una correcta aplicación de restricciones de precios.

### Cambios realizados:

- Ahora la validación primero verifica si el cliente tiene una tarifa especial asignada.

- Se considera que una tarifa es "especial" si su ID es diferente de 28 (3.Contado CMP (PYG)).

- Si el cliente tiene una tarifa especial, se permite la venta sin restricciones.

- Si el cliente no tiene una tarifa especial o no tiene tarifa asignada, se valida el precio según la tarifa del grupo del vendedor.

- Se mantiene el comportamiento de omitir la validación para los usuarios con permisos especiales.